### PR TITLE
bump minimum version of deepdiff

### DIFF
--- a/drs-configuration-synchronizer/cfn/lambda/drs-configuration-synchronizer/src/requirements.txt
+++ b/drs-configuration-synchronizer/cfn/lambda/drs-configuration-synchronizer/src/requirements.txt
@@ -1,4 +1,4 @@
 # https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
 aws-lambda-powertools~=1.30.0
 PyYAML~=6.0
-deepdiff~=6.2.1
+deepdiff~=6.2.3


### PR DESCRIPTION
This bumps the minimum version of deepdiff to 6.2.3 for the drs-configuration-synchronizer.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.