### PR TITLE
Enabling ACLs on logging bucket

### DIFF
--- a/drs-plan-automation/cfn/cloudfront/gui-distribution.yaml
+++ b/drs-plan-automation/cfn/cloudfront/gui-distribution.yaml
@@ -61,6 +61,9 @@ Resources:
         IgnorePublicAcls : true
         RestrictPublicBuckets : true
       AccessControl: LogDeliveryWrite
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerPreferred
       VersioningConfiguration:
         Status: Enabled
       BucketEncryption:


### PR DESCRIPTION
Description of changes:
 - Enabling ACLs on the logging bucket used for the GUI.  With the April 2023 change of Amazon now disabling ACL's on any new bucket creations, this must now be enabled in order to complete the deployment.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
